### PR TITLE
fix: resolve semgrep security findings

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -238,6 +238,8 @@ jobs:
 
       - name: Commit screenshots to repo
         if: github.event_name == 'push'
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p screenshots
           cp screenshot-login.png      screenshots/login.png
@@ -254,7 +256,7 @@ jobs:
           git add screenshots/
           git diff --staged --quiet && echo "No changes to screenshots." || \
             git commit -m "chore: update demo screenshots [skip ci]" && \
-            git push origin HEAD:${{ github.ref_name }}
+            git push origin "HEAD:$BRANCH_NAME"
 
       - name: Upload screenshots as artifact
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [v0.3.1] - 2026-06-26
+
+### Fixed
+- Security: path traversal in `/uploads/<filename>` — route now sanitises the filename with `secure_filename()` before passing it to `send_from_directory`, and returns 404 for empty/invalid names.
+- Security: NaN/Infinity injection — `streak_multiplier` from form input is now validated with `math.isnan`/`math.isinf`; invalid or non-positive values fall back to `2.0`.
+- Security: raw HTML in token-based approve/reject responses — `quick_approve` and `quick_reject` now use `render_template_string` with Jinja2 auto-escaping instead of manually-constructed f-string HTML.
+- Security: shell injection in CI — `${{ github.ref_name }}` in the screenshot commit step is now passed through an `env:` variable (`BRANCH_NAME`) and quoted in the `run:` script, preventing expression injection.
+
 ## [v0.3.0] - 2026-03-29
 
 ### Added

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import glob as _glob
 import html
 import logging
+import math
 import mimetypes
 import os
 import re
@@ -16,8 +17,8 @@ import apprise
 import requests as http_requests
 from urllib.parse import quote as _urlquote
 from flask import (
-    Flask, Response, flash, make_response, redirect, render_template, request,
-    send_from_directory, session, url_for,
+    Flask, Response, abort, flash, make_response, redirect, render_template,
+    render_template_string, request, send_from_directory, session, url_for,
 )
 from flask_login import (
     LoginManager, UserMixin, current_user, login_required, login_user, logout_user,
@@ -1569,7 +1570,12 @@ def create_habit():
     penalty_amount = int(request.form.get('penalty_amount') or 0)
     streak_enabled = 'streak_enabled' in request.form
     streak_milestone = int(request.form.get('streak_milestone') or 5)
-    streak_multiplier = float(request.form.get('streak_multiplier') or 2.0)
+    try:
+        streak_multiplier = float(request.form.get('streak_multiplier') or 2.0)
+        if math.isnan(streak_multiplier) or math.isinf(streak_multiplier) or streak_multiplier <= 0:
+            streak_multiplier = 2.0
+    except (ValueError, TypeError):
+        streak_multiplier = 2.0
     coins_reward = int(request.form.get('coins_reward') or 1)
     coins_streak_bonus = int(request.form.get('coins_streak_bonus') or 0)
 
@@ -1689,7 +1695,13 @@ def quick_approve(completion_id, token):
     completion.action_token = None  # invalidate token
     db.session.commit()
     send_notification(f"✅ **{user.name}** completed **{completion.habit_name}**! (Approved via link){bonus_msg}", completion.image_filename)
-    return f"<html><body style='font-family:sans-serif;text-align:center;padding:2rem'><h2>✅ Quest Approved!</h2><p><strong>{html.escape(user.name)}</strong> — <em>{html.escape(completion.habit_name)}</em></p><p>Gems awarded.{html.escape(bonus_msg)}</p></body></html>", 200
+    return render_template_string(
+        "<html><body style='font-family:sans-serif;text-align:center;padding:2rem'>"
+        "<h2>✅ Quest Approved!</h2>"
+        "<p><strong>{{ name }}</strong> — <em>{{ habit }}</em></p>"
+        "<p>Gems awarded.{{ bonus }}</p></body></html>",
+        name=user.name, habit=completion.habit_name, bonus=bonus_msg
+    ), 200
 
 @app.route('/quest/reject/<int:completion_id>/<token>')
 def quick_reject(completion_id, token):
@@ -1706,7 +1718,12 @@ def quick_reject(completion_id, token):
     completion.action_token = None  # invalidate token
     db.session.commit()
     send_notification(f"❌ **{user.name}**'s quest **{completion.habit_name}** was rejected (via link).")
-    return f"<html><body style='font-family:sans-serif;text-align:center;padding:2rem'><h2>❌ Quest Rejected</h2><p><strong>{html.escape(user.name)}</strong> — <em>{html.escape(completion.habit_name)}</em></p></body></html>", 200
+    return render_template_string(
+        "<html><body style='font-family:sans-serif;text-align:center;padding:2rem'>"
+        "<h2>❌ Quest Rejected</h2>"
+        "<p><strong>{{ name }}</strong> — <em>{{ habit }}</em></p></body></html>",
+        name=user.name, habit=completion.habit_name
+    ), 200
 
 @app.route('/admin/history')
 @login_required
@@ -2029,6 +2046,9 @@ def adjust_coins():
 # UPDATED: Add header for inline image display and guess MIME type
 @app.route('/uploads/<filename>')
 def uploaded_file(filename):
+    filename = secure_filename(filename)
+    if not filename:
+        abort(404)
     # Guess mime type based on extension
     mime_type, _ = mimetypes.guess_type(filename)
     


### PR DESCRIPTION
## Summary

- **Path traversal** (`/uploads/<filename>`): sanitise the URL parameter with `secure_filename()` before passing to `send_from_directory`; return 404 for empty/invalid results.
- **NaN injection** (`streak_multiplier`): wrap the `float()` cast in a try/except and reject `nan`/`inf`/non-positive values, falling back to `2.0`.
- **raw-html-format** (`quick_approve` / `quick_reject`): replaced manually-constructed f-string HTML responses with `render_template_string`, letting Jinja2 auto-escape handle user-controlled values instead of manual `html.escape()` calls.
- **Shell injection in CI**: moved `${{ github.ref_name }}` out of the `run:` script body into an `env:` block (`BRANCH_NAME`) and quoted the variable in the shell command, preventing expression injection.

Two findings are not addressed:
- **sqlalchemy-execute-raw-query**: all `cursor.execute()` calls in `perform_db_migration` use either fully hardcoded SQL strings or values pre-validated by `_SAFE_COL_NAME_RE`/`_SAFE_COL_DEF_RE` regex guards in `_ddl_add_column`. No user input reaches these queries.
- **django-no-csrf-token**: false positive — this is a Flask app with `flask-wtf` CSRF protection already enabled globally via `CSRFProtect(app)`.

## Test plan

- [ ] Upload a quest proof image and verify it still displays at `/uploads/<filename>`
- [ ] Try requesting `/uploads/../app.py` and confirm 404
- [ ] Create a habit with `streak_multiplier=nan` and confirm it defaults to `2.0`
- [ ] Approve/reject a quest via the token link and confirm the response page renders correctly
- [ ] Verify CI pipeline passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3skUsc9ZtamRZemUv5hbK

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3skUsc9ZtamRZemUv5hbK)_